### PR TITLE
FIX Don't apply widgets to all pages by default

### DIFF
--- a/mysite/_config/blog.yml
+++ b/mysite/_config/blog.yml
@@ -4,7 +4,10 @@ Only:
   moduleexists: silverstripe/widgets
 ---
 # Disable if you do not use widgets on your site
-SilverStripe\CMS\Model\SiteTree:
+SilverStripe\Blog\Model\Blog:
+  extensions:
+    - SilverStripe\Widgets\Extensions\WidgetPageExtension
+SilverStripe\Blog\Model\BlogPost:
   extensions:
     - SilverStripe\Widgets\Extensions\WidgetPageExtension
 


### PR DESCRIPTION
This functionality will be both surprising and for the most part unwanted. Widgets were and are originally intended to complement blog's functionality by rendering things in a side bar such as tag clouds and archive calendars - so it still makes sense to apply the extension to blogs & blog posts by default.

