### PR TITLE
WIP: FIX enable CI tests to pass by including theme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: trusty
 env:
   global:
     - COMPOSER_ROOT_VERSION=1.x-dev
+    - SS_BASE_URL="http://localhost:8080/"
 
 matrix:
   include:
@@ -21,6 +22,7 @@ before_script:
 
   # Install composer dependencies
   - composer validate
+  - composer require --no-update silverstripe/installer '4.1.x-dev'
   - if [[ "$DB" == "PGSQL" ]]; then composer require --no-update silverstripe/postgresql:2.0.x-dev; fi
   - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
 
 	<testsuite name="Default">
 		<directory>vendor/silverstripe/blog/tests</directory>


### PR DESCRIPTION
Some of the tests (particularly Blog module) rely on the presence of a
theme (or in the least a Page template that supports $Layout) in order to
pass (by asserting that specified content is in the body). As recipe-blog
does not include a theme, this was seeing the tests fail - so fix this by
adjusting the TravisCI configuration file accordingly.

Resolves #5 