### PR TITLE
MNT Conflict older versions of lumberjack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "silverstripe/gridfieldqueuedexport": "^2",
         "symbiote/silverstripe-queuedjobs": "^4.9"
     },
+    "conflict": {
+        "silverstripe/lumberjack": "<2.1.0"
+    },
     "extra": {
         "project-files": ["app/*"]
     },


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Fixes issue with prefer-lowest build 

```
1) SilverStripe\Lumberjack\Tests\LumberjackTest::testGetExcludedSiteTreeClassNames
LogicException: Class SilverStripe\Lumberjack\Tests\Stub\SiteTree\LumberjackStub not loaded by manifest, or no database table configured in /home/runner/work/recipe-blog/recipe-blog/vendor/silverstripe/framework/src/ORM/DataObject.php:3600
```

https://github.com/silverstripe/recipe-blog/runs/7440638381?check_suite_focus=true#step:12:69

I'm not sure exactly what in 2.1.0 fixes this - https://github.com/silverstripe/silverstripe-lumberjack/compare/2.0.0...2.1.0
